### PR TITLE
Scaffold source layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,19 @@ With this server, you can **manage Backlog issues, comments, wikis, and attachme
 ```bash
 backlog-mcp-server/
 ├── src/
-│   ├── server.ts        # MCP Server 入口
-│   ├── backlogClient.ts # Backlog REST API 封装
-│   ├── tools/           # 各类工具定义 (issues/wiki/comments/attachments)
-│   └── utils/           # 公共方法 (鉴权/错误处理/分页等)
-├── package.json
-├── tsconfig.json
+│   ├── server.ts              # MCP Server 入口
+│   ├── backlogClient.ts       # Backlog REST API 封装
+│   ├── tools/                 # MCP 工具实现
+│   │   ├── issues.ts          # 处理 Backlog 任务
+│   │   ├── comments.ts        # 处理任务评论
+│   │   ├── wiki.ts            # Wiki 页面工具
+│   │   ├── attachments.ts     # 附件相关操作
+│   │   └── activities.ts      # 项目活动日志
+│   └── utils/                 # 通用工具函数
+│       ├── auth.ts            # 鉴权辅助
+│       ├── errors.ts          # 错误格式化
+│       └── pagination.ts      # 分页处理
+├── docs/                      # 文档与设计草稿
 ├── README.md
 └── LICENSE
 ```

--- a/src/backlogClient.ts
+++ b/src/backlogClient.ts
@@ -1,0 +1,128 @@
+import { createAuthHeaders } from './utils/auth';
+import { BacklogError, normalizeError } from './utils/errors';
+import { PaginationOptions, buildPaginationParams } from './utils/pagination';
+
+export interface BacklogConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+type ClientRequestOptions = {
+  method?: HttpMethod;
+  payload?: unknown;
+  query?: Record<string, string | number | undefined>;
+};
+
+export type IssuePayload = {
+  summary: string;
+  description?: string;
+  [key: string]: unknown;
+};
+
+export type CommentPayload = {
+  content: string;
+  notifiedUserIds?: number[];
+  [key: string]: unknown;
+};
+
+export type AttachmentPayload = {
+  fileName: string;
+  contentType: string;
+  data: string;
+};
+
+export class BacklogClient {
+  constructor(private readonly config: BacklogConfig) {}
+
+  public async listIssues(projectKey: string, pagination?: PaginationOptions) {
+    return this.request(`/projects/${projectKey}/issues`, {
+      method: 'GET',
+      query: buildPaginationParams(pagination),
+    });
+  }
+
+  public async createIssue(projectKey: string, payload: IssuePayload) {
+    return this.request(`/projects/${projectKey}/issues`, {
+      method: 'POST',
+      payload,
+    });
+  }
+
+  public async listComments(issueId: number, pagination?: PaginationOptions) {
+    return this.request(`/issues/${issueId}/comments`, {
+      method: 'GET',
+      query: buildPaginationParams(pagination),
+    });
+  }
+
+  public async createComment(issueId: number, payload: CommentPayload) {
+    return this.request(`/issues/${issueId}/comments`, {
+      method: 'POST',
+      payload,
+    });
+  }
+
+  public async listWikiPages(projectIdOrKey: string, pagination?: PaginationOptions) {
+    return this.request(`/projects/${projectIdOrKey}/wikis`, {
+      method: 'GET',
+      query: buildPaginationParams(pagination),
+    });
+  }
+
+  public async listAttachments(issueId: number) {
+    return this.request(`/issues/${issueId}/attachments`, {
+      method: 'GET',
+    });
+  }
+
+  public async uploadAttachment(issueId: number, payload: AttachmentPayload) {
+    return this.request(`/issues/${issueId}/attachments`, {
+      method: 'POST',
+      payload,
+    });
+  }
+
+  public async listActivities(projectKey: string, pagination?: PaginationOptions) {
+    return this.request(`/projects/${projectKey}/activities`, {
+      method: 'GET',
+      query: buildPaginationParams(pagination),
+    });
+  }
+
+  private buildUrl(path: string, query?: Record<string, string | number | undefined>): string {
+    const url = new URL(path, this.config.baseUrl);
+
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined && value !== null) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    return url.toString();
+  }
+
+  private async request<T>(path: string, options: ClientRequestOptions = {}): Promise<T> {
+    const url = this.buildUrl(path, options.query);
+    const headers = {
+      'Content-Type': 'application/json',
+      ...createAuthHeaders(this.config),
+    };
+
+    try {
+      const response = {
+        url,
+        method: options.method ?? 'GET',
+        headers,
+        payload: options.payload ?? null,
+      };
+
+      return response as T;
+    } catch (error) {
+      throw normalizeError(error, new BacklogError('Failed to execute Backlog request'));
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,43 @@
+import { BacklogClient, BacklogConfig } from './backlogClient';
+import { createIssuesTool } from './tools/issues';
+import { createCommentsTool } from './tools/comments';
+import { createWikiTool } from './tools/wiki';
+import { createAttachmentsTool } from './tools/attachments';
+import { createActivitiesTool } from './tools/activities';
+
+type Tool = {
+  name: string;
+  description: string;
+  execute: (payload: unknown) => Promise<unknown>;
+};
+
+export class BacklogMcpServer {
+  private readonly client: BacklogClient;
+  private readonly tools: Tool[];
+
+  constructor(config: BacklogConfig) {
+    this.client = new BacklogClient(config);
+    this.tools = [
+      createIssuesTool(this.client),
+      createCommentsTool(this.client),
+      createWikiTool(this.client),
+      createAttachmentsTool(this.client),
+      createActivitiesTool(this.client),
+    ];
+  }
+
+  public listTools(): Tool[] {
+    return this.tools;
+  }
+
+  public async start(): Promise<void> {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Backlog MCP server initialized with the following tools:');
+      for (const tool of this.tools) {
+        console.log(`• ${tool.name} – ${tool.description}`);
+      }
+    }
+  }
+}
+
+export const createServer = (config: BacklogConfig) => new BacklogMcpServer(config);

--- a/src/tools/activities.ts
+++ b/src/tools/activities.ts
@@ -1,0 +1,18 @@
+import { BacklogClient } from '../backlogClient';
+import { PaginationOptions } from '../utils/pagination';
+import type { Tool } from './issues';
+
+export interface ActivitiesToolInput extends PaginationOptions {
+  projectKey: string;
+}
+
+export const createActivitiesTool = (
+  client: BacklogClient,
+): Tool<ActivitiesToolInput, unknown> => ({
+  name: 'activities',
+  description: 'Inspect Backlog project activities.',
+  async execute(payload) {
+    const { projectKey, ...pagination } = payload;
+    return client.listActivities(projectKey, pagination as PaginationOptions);
+  },
+});

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,0 +1,28 @@
+import { AttachmentPayload, BacklogClient } from '../backlogClient';
+import type { Tool } from './issues';
+
+export interface AttachmentsToolInput {
+  issueId: number;
+  action?: 'list' | 'upload';
+  attachment?: AttachmentPayload;
+}
+
+export const createAttachmentsTool = (
+  client: BacklogClient,
+): Tool<AttachmentsToolInput, unknown> => ({
+  name: 'attachments',
+  description: 'Manage Backlog issue attachments.',
+  async execute(payload) {
+    const { action = 'list', issueId, attachment } = payload;
+
+    if (action === 'upload') {
+      if (!attachment) {
+        throw new Error('Attachment payload is required when uploading to Backlog.');
+      }
+
+      return client.uploadAttachment(issueId, attachment);
+    }
+
+    return client.listAttachments(issueId);
+  },
+});

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -1,0 +1,29 @@
+import { BacklogClient, CommentPayload } from '../backlogClient';
+import { PaginationOptions } from '../utils/pagination';
+import type { Tool } from './issues';
+
+export interface CommentsToolInput extends PaginationOptions {
+  issueId: number;
+  action?: 'list' | 'create';
+  comment?: CommentPayload;
+}
+
+export const createCommentsTool = (
+  client: BacklogClient,
+): Tool<CommentsToolInput, unknown> => ({
+  name: 'comments',
+  description: 'List or create comments for a Backlog issue.',
+  async execute(payload) {
+    const { action = 'list', issueId, comment, ...pagination } = payload;
+
+    if (action === 'create') {
+      if (!comment) {
+        throw new Error('Comment payload is required when creating a Backlog comment.');
+      }
+
+      return client.createComment(issueId, comment);
+    }
+
+    return client.listComments(issueId, pagination as PaginationOptions);
+  },
+});

--- a/src/tools/issues.ts
+++ b/src/tools/issues.ts
@@ -1,0 +1,34 @@
+import { BacklogClient, IssuePayload } from '../backlogClient';
+import { PaginationOptions } from '../utils/pagination';
+
+export interface Tool<Payload, Result> {
+  name: string;
+  description: string;
+  execute: (payload: Payload) => Promise<Result>;
+}
+
+export interface IssuesToolInput extends PaginationOptions {
+  projectKey: string;
+  action?: 'list' | 'create';
+  issue?: IssuePayload;
+}
+
+export const createIssuesTool = (
+  client: BacklogClient,
+): Tool<IssuesToolInput, unknown> => ({
+  name: 'issues',
+  description: 'List or create Backlog issues.',
+  async execute(payload) {
+    const { action = 'list', projectKey, issue, ...pagination } = payload;
+
+    if (action === 'create') {
+      if (!issue) {
+        throw new Error('Issue payload is required when creating a Backlog issue.');
+      }
+
+      return client.createIssue(projectKey, issue);
+    }
+
+    return client.listIssues(projectKey, pagination as PaginationOptions);
+  },
+});

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -1,0 +1,18 @@
+import { BacklogClient } from '../backlogClient';
+import { PaginationOptions } from '../utils/pagination';
+import type { Tool } from './issues';
+
+export interface WikiToolInput extends PaginationOptions {
+  projectKeyOrId: string;
+}
+
+export const createWikiTool = (
+  client: BacklogClient,
+): Tool<WikiToolInput, unknown> => ({
+  name: 'wiki',
+  description: 'Browse Backlog Wiki pages.',
+  async execute(payload) {
+    const { projectKeyOrId, ...pagination } = payload;
+    return client.listWikiPages(projectKeyOrId, pagination as PaginationOptions);
+  },
+});

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,17 @@
+export interface AuthConfig {
+  apiKey: string;
+}
+
+export interface AuthHeaders {
+  [header: string]: string;
+}
+
+export const createAuthHeaders = (config: AuthConfig): AuthHeaders => {
+  if (!config.apiKey) {
+    throw new Error('Backlog API key is required to authenticate requests.');
+  }
+
+  return {
+    'X-API-Key': config.apiKey,
+  };
+};

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,46 @@
+export interface BacklogErrorOptions {
+  status?: number;
+  cause?: unknown;
+  details?: unknown;
+}
+
+export class BacklogError extends Error {
+  public readonly status?: number;
+  public readonly details?: unknown;
+
+  constructor(message: string, options: BacklogErrorOptions = {}) {
+    super(message);
+    this.name = 'BacklogError';
+    this.status = options.status;
+    this.details = options.details;
+
+    if (options.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+export const isBacklogError = (error: unknown): error is BacklogError =>
+  error instanceof BacklogError;
+
+export const normalizeError = (
+  error: unknown,
+  fallback?: BacklogError,
+): BacklogError => {
+  if (isBacklogError(error)) {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return new BacklogError(error.message, { cause: error });
+  }
+
+  if (fallback) {
+    return new BacklogError(fallback.message, {
+      cause: fallback,
+      details: error,
+    });
+  }
+
+  return new BacklogError('Unknown Backlog client error', { details: error });
+};

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,46 @@
+export interface PaginationOptions {
+  offset?: number;
+  limit?: number;
+}
+
+export const normalizePagination = (
+  options?: PaginationOptions,
+): PaginationOptions | undefined => {
+  if (!options) {
+    return undefined;
+  }
+
+  const normalized: PaginationOptions = {};
+
+  if (typeof options.offset === 'number' && Number.isFinite(options.offset)) {
+    normalized.offset = Math.max(0, Math.floor(options.offset));
+  }
+
+  if (typeof options.limit === 'number' && Number.isFinite(options.limit)) {
+    normalized.limit = Math.max(1, Math.floor(options.limit));
+  }
+
+  return normalized;
+};
+
+export const buildPaginationParams = (
+  options?: PaginationOptions,
+): Record<string, number> | undefined => {
+  const normalized = normalizePagination(options);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  const params: Record<string, number> = {};
+
+  if (normalized.offset !== undefined) {
+    params.offset = normalized.offset;
+  }
+
+  if (normalized.limit !== undefined) {
+    params.count = normalized.limit;
+  }
+
+  return Object.keys(params).length > 0 ? params : undefined;
+};


### PR DESCRIPTION
## Summary
- add a Backlog MCP server entry point and register placeholder tools
- scaffold a Backlog REST client plus tool stubs for issues, comments, wiki, attachments, and activities
- document the new source tree structure in the README

## Testing
- not run (tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d245c1c9288327b8ca3fb91b32c617