### PR TITLE
Add MCP tools for Backlog issue CRUD operations

### DIFF
--- a/src/tools/issues.ts
+++ b/src/tools/issues.ts
@@ -38,6 +38,19 @@ type BacklogIssue = z.infer<typeof backlogIssueSchema>;
 
 const backlogIssueListSchema = z.array(backlogIssueSchema);
 
+const issuePayloadSchema = z
+  .object({
+    summary: z.string().trim().min(1, 'summary is required'),
+    description: z.string().optional(),
+  })
+  .passthrough();
+
+const issueUpdatePayloadSchema = issuePayloadSchema
+  .partial()
+  .refine((data) => Object.values(data).some((value) => value !== undefined), {
+    message: 'At least one field must be provided to update the issue.',
+  });
+
 const listIssuesInputSchema = z.object({
   projectKey: z.string().trim().min(1, 'projectKey is required'),
   keyword: z.string().trim().optional(),
@@ -92,6 +105,46 @@ const toIssueDetails = (issue: BacklogIssue): IssueDetails => ({
   assignee: issue.assignee?.name ?? null,
 });
 
+const createIssueInputSchema = z.object({
+  projectKey: z.string().trim().min(1, 'projectKey is required'),
+  issue: issuePayloadSchema,
+});
+
+export type CreateIssueToolInput = z.infer<typeof createIssueInputSchema>;
+
+const updateIssueInputSchema = z.object({
+  issueIdOrKey: z.string().trim().min(1, 'issueIdOrKey is required'),
+  updates: issueUpdatePayloadSchema,
+});
+
+export type UpdateIssueToolInput = z.infer<typeof updateIssueInputSchema>;
+
+const deleteIssueInputSchema = z.object({
+  issueIdOrKey: z.string().trim().min(1, 'issueIdOrKey is required'),
+});
+
+export type DeleteIssueToolInput = z.infer<typeof deleteIssueInputSchema>;
+
+const transitionIssueInputSchema = z.object({
+  issueIdOrKey: z.string().trim().min(1, 'issueIdOrKey is required'),
+  statusId: z
+    .number()
+    .int('statusId must be an integer value')
+    .positive('statusId must be greater than zero'),
+  comment: z.string().trim().min(1).optional(),
+});
+
+export type TransitionIssueToolInput = z.infer<typeof transitionIssueInputSchema>;
+
+const removeUndefinedValues = <T extends Record<string, unknown>>(payload: T) => {
+  return Object.entries(payload).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    if (value !== undefined) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
 export const createListIssuesTool = (
   client: BacklogClient,
 ): Tool<ListIssuesToolInput, IssueListItem[]> => ({
@@ -138,6 +191,104 @@ export const createGetIssueTool = (
     const issue = backlogIssueSchema.parse(issueResponse);
 
     return toIssueDetails(issue);
+  },
+});
+
+export interface CreateIssueResult {
+  issueKey: string;
+}
+
+export const createCreateIssueTool = (
+  client: BacklogClient,
+): Tool<CreateIssueToolInput, CreateIssueResult> => ({
+  name: 'createIssue',
+  description: 'Create a new Backlog issue.',
+  async execute(payload) {
+    const { projectKey, issue } = createIssueInputSchema.parse(payload);
+
+    const sanitizedIssuePayload = removeUndefinedValues(issue);
+
+    const createdIssueResponse = await client.post<unknown>(
+      `/projects/${encodeURIComponent(projectKey)}/issues`,
+      sanitizedIssuePayload,
+    );
+
+    const createdIssue = backlogIssueSchema.parse(createdIssueResponse);
+
+    return { issueKey: createdIssue.issueKey };
+  },
+});
+
+export interface UpdateIssueResult {
+  issueKey: string;
+}
+
+export const createUpdateIssueTool = (
+  client: BacklogClient,
+): Tool<UpdateIssueToolInput, UpdateIssueResult> => ({
+  name: 'updateIssue',
+  description: 'Update fields of an existing Backlog issue.',
+  async execute(payload) {
+    const { issueIdOrKey, updates } = updateIssueInputSchema.parse(payload);
+
+    const sanitizedUpdates = removeUndefinedValues(updates);
+
+    const updatedIssueResponse = await client.patch<unknown>(
+      `/issues/${encodeURIComponent(issueIdOrKey)}`,
+      sanitizedUpdates,
+    );
+
+    const updatedIssue = backlogIssueSchema.parse(updatedIssueResponse);
+
+    return { issueKey: updatedIssue.issueKey };
+  },
+});
+
+export interface DeleteIssueResult {
+  status: 'deleted';
+  issueKey: string;
+}
+
+export const createDeleteIssueTool = (
+  client: BacklogClient,
+): Tool<DeleteIssueToolInput, DeleteIssueResult> => ({
+  name: 'deleteIssue',
+  description: 'Delete a Backlog issue.',
+  async execute(payload) {
+    const { issueIdOrKey } = deleteIssueInputSchema.parse(payload);
+
+    await client.delete(`/issues/${encodeURIComponent(issueIdOrKey)}`);
+
+    return { status: 'deleted', issueKey: issueIdOrKey };
+  },
+});
+
+export interface TransitionIssueResult {
+  issueKey: string;
+  status: string | null;
+}
+
+export const createTransitionIssueTool = (
+  client: BacklogClient,
+): Tool<TransitionIssueToolInput, TransitionIssueResult> => ({
+  name: 'transitionIssue',
+  description: 'Change the workflow status of a Backlog issue.',
+  async execute(payload) {
+    const { issueIdOrKey, statusId, comment } = transitionIssueInputSchema.parse(payload);
+
+    const transitionPayload = removeUndefinedValues({ statusId, comment });
+
+    const transitionedIssueResponse = await client.post<unknown>(
+      `/issues/${encodeURIComponent(issueIdOrKey)}/status`,
+      transitionPayload,
+    );
+
+    const transitionedIssue = backlogIssueSchema.parse(transitionedIssueResponse);
+
+    return {
+      issueKey: transitionedIssue.issueKey,
+      status: transitionedIssue.status?.name ?? null,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- define zod schemas for creating, updating, deleting, and transitioning issues
- implement MCP tools that call the Backlog client post/patch/delete helpers and return issue metadata

## Testing
- not run (project does not include runnable npm scripts)

------
https://chatgpt.com/codex/tasks/task_e_68d2a8500a8c832785b83c6a404e1258