### PR TITLE
Implement attachment management and activity retrieval tools

### DIFF
--- a/src/tools/activities.ts
+++ b/src/tools/activities.ts
@@ -1,18 +1,142 @@
+import { z } from 'zod';
+
 import { BacklogClient } from '../backlogClient';
-import { PaginationOptions } from '../utils/pagination';
+import { normalizePagination } from '../utils/pagination';
 import type { Tool } from './issues';
 
-export interface ActivitiesToolInput extends PaginationOptions {
-  projectKey: string;
+const paginationSchema = z.object({
+  offset: z
+    .number({ invalid_type_error: 'offset must be a number' })
+    .int('offset must be an integer value')
+    .min(0, 'offset cannot be negative')
+    .optional(),
+  limit: z
+    .number({ invalid_type_error: 'limit must be a number' })
+    .int('limit must be an integer value')
+    .positive('limit must be greater than zero')
+    .optional(),
+});
+
+const activitiesInputSchema = z
+  .object({
+    projectKey: z.string().trim().min(1, 'projectKey is required'),
+  })
+  .merge(paginationSchema);
+
+export type ActivitiesToolInput = z.infer<typeof activitiesInputSchema>;
+
+const backlogUserSchema = z
+  .object({
+    id: z.number().optional(),
+    userId: z.string().optional(),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
+const backlogProjectSchema = z
+  .object({
+    id: z.number().optional(),
+    projectKey: z.string().optional(),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
+const backlogActivitySchema = z
+  .object({
+    id: z.number(),
+    type: z.number().optional(),
+    project: backlogProjectSchema.nullish(),
+    content: z.unknown().optional(),
+    createdUser: backlogUserSchema.nullish(),
+    created: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+type BacklogActivity = z.infer<typeof backlogActivitySchema>;
+
+const backlogActivityListSchema = z.array(backlogActivitySchema);
+
+const toUserInfo = (
+  user: z.infer<typeof backlogUserSchema> | null | undefined,
+): { id: number | null; name: string | null } | null =>
+  user
+    ? {
+        id: typeof user.id === 'number' ? user.id : null,
+        name: user.name ?? null,
+      }
+    : null;
+
+const toProjectInfo = (
+  project: z.infer<typeof backlogProjectSchema> | null | undefined,
+): { id: number | null; key: string | null; name: string | null } | null =>
+  project
+    ? {
+        id: typeof project.id === 'number' ? project.id : null,
+        key: project.projectKey ?? null,
+        name: project.name ?? null,
+      }
+    : null;
+
+const toDetails = (content: unknown): Record<string, unknown> => {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) {
+    return {};
+  }
+
+  return { ...(content as Record<string, unknown>) };
+};
+
+export interface ActivityInfo {
+  id: number;
+  type: number | null;
+  project: { id: number | null; key: string | null; name: string | null } | null;
+  created: string | null;
+  createdBy: { id: number | null; name: string | null } | null;
+  details: Record<string, unknown>;
 }
+
+const toActivityInfo = (activity: BacklogActivity): ActivityInfo => ({
+  id: activity.id,
+  type: typeof activity.type === 'number' ? activity.type : null,
+  project: toProjectInfo(activity.project ?? null),
+  created: activity.created ?? null,
+  createdBy: toUserInfo(activity.createdUser ?? null),
+  details: toDetails(activity.content),
+});
+
+export interface GetActivitiesResult {
+  activities: ActivityInfo[];
+  nextOffset: number | null;
+}
+
+const getActivities = async (
+  client: BacklogClient,
+  payload: ActivitiesToolInput,
+): Promise<GetActivitiesResult> => {
+  const { projectKey, offset, limit } = activitiesInputSchema.parse(payload);
+
+  const normalizedPagination = normalizePagination({ offset, limit });
+  const response = await client.listActivities(projectKey, normalizedPagination);
+  const activities = backlogActivityListSchema.parse(response);
+
+  const mapped = activities.map(toActivityInfo);
+
+  const effectiveOffset = normalizedPagination?.offset ?? 0;
+  const effectiveLimit = normalizedPagination?.limit;
+
+  const nextOffset =
+    typeof effectiveLimit === 'number' && activities.length === effectiveLimit
+      ? effectiveOffset + effectiveLimit
+      : null;
+
+  return { activities: mapped, nextOffset };
+};
 
 export const createActivitiesTool = (
   client: BacklogClient,
-): Tool<ActivitiesToolInput, unknown> => ({
+): Tool<ActivitiesToolInput, GetActivitiesResult> => ({
   name: 'activities',
   description: 'Inspect Backlog project activities.',
   async execute(payload) {
-    const { projectKey, ...pagination } = payload;
-    return client.listActivities(projectKey, pagination as PaginationOptions);
+    return getActivities(client, payload);
   },
 });

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,28 +1,170 @@
+import { z } from 'zod';
+
 import { AttachmentPayload, BacklogClient } from '../backlogClient';
 import type { Tool } from './issues';
 
-export interface AttachmentsToolInput {
-  issueId: number;
-  action?: 'list' | 'upload';
-  attachment?: AttachmentPayload;
+const issueIdSchema = z
+  .number({ invalid_type_error: 'issueId must be a number' })
+  .int('issueId must be an integer value')
+  .positive('issueId must be greater than zero');
+
+const attachmentIdSchema = z
+  .number({ invalid_type_error: 'attachmentId must be a number' })
+  .int('attachmentId must be an integer value')
+  .positive('attachmentId must be greater than zero');
+
+const attachmentPayloadSchema = z
+  .object({
+    fileName: z.string().trim().min(1, 'fileName is required'),
+    contentType: z.string().trim().min(1, 'contentType is required'),
+    data: z.string().trim().min(1, 'data is required'),
+  })
+  .passthrough();
+
+const backlogUserSchema = z
+  .object({
+    id: z.number().optional(),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
+const backlogAttachmentSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    size: z.number().optional(),
+    createdUser: backlogUserSchema.nullish(),
+    created: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+type BacklogAttachment = z.infer<typeof backlogAttachmentSchema>;
+
+const backlogAttachmentListSchema = z.array(backlogAttachmentSchema);
+
+const attachmentsToolInputSchema = z.object({
+  issueId: issueIdSchema,
+  action: z.enum(['list', 'upload', 'delete']).optional(),
+  attachment: attachmentPayloadSchema.optional(),
+  attachmentId: attachmentIdSchema.optional(),
+});
+
+export interface AttachmentInfo {
+  id: number;
+  name: string;
+  size: number | null;
+  created: string | null;
+  createdBy: { id: number | null; name: string | null } | null;
 }
+
+const toAttachmentInfo = (attachment: BacklogAttachment): AttachmentInfo => ({
+  id: attachment.id,
+  name: attachment.name,
+  size: typeof attachment.size === 'number' ? attachment.size : null,
+  created: attachment.created ?? null,
+  createdBy: attachment.createdUser
+    ? {
+        id:
+          typeof attachment.createdUser.id === 'number'
+            ? attachment.createdUser.id
+            : null,
+        name: attachment.createdUser.name ?? null,
+      }
+    : null,
+});
+
+export interface ListAttachmentsResult {
+  attachments: AttachmentInfo[];
+}
+
+export interface UploadAttachmentResult {
+  attachment: AttachmentInfo;
+}
+
+export interface DeleteAttachmentResult {
+  status: 'deleted';
+  issueId: number;
+  attachmentId: number;
+}
+
+export type AttachmentToolResult =
+  | ListAttachmentsResult
+  | UploadAttachmentResult
+  | DeleteAttachmentResult;
+
+export type AttachmentsToolInput = z.infer<typeof attachmentsToolInputSchema>;
+
+const listAttachments = async (
+  client: BacklogClient,
+  issueId: number,
+): Promise<ListAttachmentsResult> => {
+  const validatedIssueId = issueIdSchema.parse(issueId);
+  const response = await client.listAttachments(validatedIssueId);
+  const attachments = backlogAttachmentListSchema.parse(response);
+
+  return {
+    attachments: attachments.map(toAttachmentInfo),
+  };
+};
+
+const uploadAttachment = async (
+  client: BacklogClient,
+  issueId: number,
+  payload: AttachmentPayload,
+): Promise<UploadAttachmentResult> => {
+  const validatedIssueId = issueIdSchema.parse(issueId);
+  const sanitizedPayload = attachmentPayloadSchema.parse(payload);
+
+  const response = await client.uploadAttachment(validatedIssueId, sanitizedPayload);
+  const attachment = backlogAttachmentSchema.parse(response);
+
+  return { attachment: toAttachmentInfo(attachment) };
+};
+
+const deleteAttachment = async (
+  client: BacklogClient,
+  issueId: number,
+  attachmentId: number,
+): Promise<DeleteAttachmentResult> => {
+  const validatedIssueId = issueIdSchema.parse(issueId);
+  const validatedAttachmentId = attachmentIdSchema.parse(attachmentId);
+
+  await client.delete(
+    `/issues/${encodeURIComponent(String(validatedIssueId))}/attachments/${encodeURIComponent(String(validatedAttachmentId))}`,
+  );
+
+  return {
+    status: 'deleted',
+    issueId: validatedIssueId,
+    attachmentId: validatedAttachmentId,
+  };
+};
 
 export const createAttachmentsTool = (
   client: BacklogClient,
-): Tool<AttachmentsToolInput, unknown> => ({
+): Tool<AttachmentsToolInput, AttachmentToolResult> => ({
   name: 'attachments',
   description: 'Manage Backlog issue attachments.',
   async execute(payload) {
-    const { action = 'list', issueId, attachment } = payload;
+    const { issueId, action = 'list', attachment, attachmentId } =
+      attachmentsToolInputSchema.parse(payload);
 
     if (action === 'upload') {
       if (!attachment) {
         throw new Error('Attachment payload is required when uploading to Backlog.');
       }
 
-      return client.uploadAttachment(issueId, attachment);
+      return uploadAttachment(client, issueId, attachment);
     }
 
-    return client.listAttachments(issueId);
+    if (action === 'delete') {
+      if (typeof attachmentId !== 'number') {
+        throw new Error('Attachment ID is required when deleting a Backlog attachment.');
+      }
+
+      return deleteAttachment(client, issueId, attachmentId);
+    }
+
+    return listAttachments(client, issueId);
   },
 });


### PR DESCRIPTION
## Summary
- add schema validation and structured responses for the attachments MCP tool, including upload and delete helpers
- implement the activities tool with pagination normalization and normalized activity details

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d4ad03f93c832787da38e0f744007d