### PR TITLE
Add CI status and coverage badges

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "coverage",
+  "message": "54.9%",
+  "color": "orange"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   build-and-test:
     # Use Ubuntu as the build environment because it closely matches local development.
@@ -38,8 +41,11 @@ jobs:
         run: npm run build
 
       # Execute the unit test suite with Jest to ensure application correctness.
-      - name: Run tests
-        run: npm test -- --ci --runInBand
+      - name: Run tests with coverage
+        run: npm test -- --ci --runInBand --coverage
+
+      - name: Generate coverage badge data
+        run: npm run coverage:badge
 
       # Upload Jest coverage results as an artifact to aid in reviewing test completeness.
       - name: Upload coverage report
@@ -49,3 +55,10 @@ jobs:
           name: coverage-report
           path: coverage
           if-no-files-found: ignore
+
+      - name: Commit updated coverage badge
+        if: github.ref == 'refs/heads/main'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update coverage badge'
+          file_pattern: .github/badges/coverage.json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Backlog MCP Server
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
-[![TypeScript](https://img.shields.io/badge/language-TypeScript-blue)](https://www.typescriptlang.org/)
-[![MCP](https://img.shields.io/badge/protocol-MCP-green)](https://github.com/modelcontextprotocol)
+[![CI](https://img.shields.io/github/actions/workflow/status/modelcontextprotocol/backlog-mcp-server/ci.yml?label=CI&logo=githubactions)](https://github.com/modelcontextprotocol/backlog-mcp-server/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/backlog-mcp-server/main/.github/badges/coverage.json)](https://github.com/modelcontextprotocol/backlog-mcp-server/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
+![Node.js ≥ 18](https://img.shields.io/badge/Node.js-%E2%89%A518-43853D?logo=node.js&logoColor=white)
+[![TypeScript 5.9](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+![Tests: Jest](https://img.shields.io/badge/Tests-Jest-99424F?logo=jest&logoColor=white)
+[![Protocol: MCP](https://img.shields.io/badge/Protocol-MCP-1F6FEB?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUwIiBoZWlnaHQ9IjE1MCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTUwIDBDMjIuMzc2IDAgMCAyMi4zNzYgMCA1MHMgMjIuMzc2IDUwIDUwIDUwIDUwLTIyLjM3NiA1MC01MFM3Ny42MjQgMCA1MCAweiIgZmlsbD0iI2ZmZiIvPjxwYXRoIGQ9Ik01MCAxNS4yNWMtMTkuMjI1IDAtMzQuNzUgMTUuNTI1LTM0Ljc1IDM0Ljc1UzMwLjc3NSA4NC43NSA1MCA4NC43NSA4NC43NSA2OS4yMjUgODQuNzUgNTBTNjkuMjI1IDE1LjI1IDUwIDE1LjI1em0tNi4yNSAyMS4yNWE2LjI1IDYuMjUgMCAxIDEgMTIuNSAwIDYuMjUgNi4yNSAwIDEgMS0xMi41IDB6bTAgMTUuNjI1YTYuMjUgNi4yNSAwIDEgMSAxMi41IDAgNi4yNSA2LjI1IDAgMSAxLTEyLjUgMHptNi4yNSA0My4xMjVhNi4yNSA2LjI1IDAgMSAxIDEyLjUgMCA2LjI1IDYuMjUgMCAxIDEtMTIuNSAwem0yMS44NzUtMTcuNWExMi41IDEyLjUgMCAxIDEgMjUgMCAxMi41IDEyLjUgMCAxIDEtMjUgMHptLTI3LjUgMTIuNWExMi41IDEyLjUgMCAxIDEgMjUgMCAxMi41IDEyLjUgMCAxIDEtMjUgMHoiIGZpbGw9IiMxZjZmZWIiLz48L3N2Zz4=)](https://github.com/modelcontextprotocol)
 
 A **Model Context Protocol (MCP) server** for [Backlog](https://backlog.com).
 With this server, you can **manage Backlog issues, comments, wikis, and attachments directly from MCP clients** such as **Codex CLI**.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "start": "node dist/server.js",
-    "test": "jest"
+    "test": "jest",
+    "coverage:badge": "node scripts/updateCoverageBadge.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.2",
@@ -26,6 +27,7 @@
     "roots": ["<rootDir>/__tests__"],
     "moduleFileExtensions": ["ts", "tsx", "js", "json"],
     "collectCoverageFrom": ["src/**/*.ts"],
-    "coveragePathIgnorePatterns": ["/node_modules/", "<rootDir>/dist/"]
+    "coveragePathIgnorePatterns": ["/node_modules/", "<rootDir>/dist/"],
+    "coverageReporters": ["text", "lcov", "json-summary"]
   }
 }

--- a/scripts/updateCoverageBadge.mjs
+++ b/scripts/updateCoverageBadge.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const summaryPath = path.resolve('coverage', 'coverage-summary.json');
+const badgePath = path.resolve('.github', 'badges', 'coverage.json');
+
+const COLORS = [
+  { threshold: 90, color: 'brightgreen' },
+  { threshold: 80, color: 'green' },
+  { threshold: 70, color: 'yellowgreen' },
+  { threshold: 60, color: 'yellow' },
+  { threshold: 50, color: 'orange' },
+];
+
+async function readCoveragePercentage() {
+  try {
+    const raw = await fs.readFile(summaryPath, 'utf8');
+    const summary = JSON.parse(raw);
+    const pct = summary?.total?.lines?.pct;
+    if (typeof pct !== 'number' || Number.isNaN(pct)) {
+      throw new Error('Coverage summary does not contain a numeric total.lines.pct value.');
+    }
+    return pct;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`Coverage summary file not found at ${summaryPath}. Did you run Jest with --coverage?`);
+    }
+    throw error;
+  }
+}
+
+function determineColor(percentage) {
+  for (const { threshold, color } of COLORS) {
+    if (percentage >= threshold) {
+      return color;
+    }
+  }
+  return 'red';
+}
+
+function formatPercentage(percentage) {
+  if (percentage >= 99.95) {
+    return '100%';
+  }
+  return `${percentage.toFixed(1)}%`;
+}
+
+async function writeBadge(percentage) {
+  await fs.mkdir(path.dirname(badgePath), { recursive: true });
+  const badge = {
+    schemaVersion: 1,
+    label: 'coverage',
+    message: formatPercentage(percentage),
+    color: determineColor(percentage),
+  };
+  await fs.writeFile(badgePath, `${JSON.stringify(badge, null, 2)}\n`, 'utf8');
+}
+
+async function main() {
+  const percentage = await readCoveragePercentage();
+  await writeBadge(percentage);
+  console.log(`Updated coverage badge to ${percentage.toFixed(2)}%.`);
+}
+
+main().catch((error) => {
+  console.error(error.message ?? error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add GitHub Actions CI status and coverage badges to the README
- update the CI workflow to run Jest with coverage, generate badge data, and auto-commit it on main
- add a script and badge data file to expose Jest line coverage via shields.io

## Testing
- npm test -- --coverage
- node scripts/updateCoverageBadge.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d7ce47e9648327bec4052ba90bd5c0