### PR TITLE
Fix README badges for CI and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Backlog MCP Server
 
-[![CI](https://img.shields.io/github/actions/workflow/status/modelcontextprotocol/backlog-mcp-server/ci.yml?label=CI&logo=githubactions)](https://github.com/modelcontextprotocol/backlog-mcp-server/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/backlog-mcp-server/main/.github/badges/coverage.json)](https://github.com/modelcontextprotocol/backlog-mcp-server/actions/workflows/ci.yml)
+[![CI](https://github.com/tempestLXC/backlog-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/tempestLXC/backlog-mcp-server/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tempestLXC/backlog-mcp-server/main/.github/badges/coverage.json)](https://github.com/tempestLXC/backlog-mcp-server/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 ![Node.js ≥ 18](https://img.shields.io/badge/Node.js-%E2%89%A518-43853D?logo=node.js&logoColor=white)
 [![TypeScript 5.9](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)


### PR DESCRIPTION
## Summary
- correct the CI badge URL in the README so it renders properly for tempestLXC/backlog-mcp-server
- fix the coverage badge link so the shield can find the JSON endpoint in the tempestLXC repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7d2b2a9208327a93604b7a0d0c3f7