### PR TITLE
Add test coverage for Backlog client and server setup

### DIFF
--- a/__tests__/backlogClient.test.ts
+++ b/__tests__/backlogClient.test.ts
@@ -1,0 +1,128 @@
+import { BacklogClient } from '../src/backlogClient';
+import { createAuthHeaders } from '../src/utils/auth';
+
+jest.mock('../src/utils/auth', () => ({
+  createAuthHeaders: jest.fn(),
+}));
+
+describe('BacklogClient', () => {
+  const originalFetch = globalThis.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createAuthHeaders as jest.Mock).mockReturnValue({ 'X-API-Key': 'mock-header' });
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('performs GET requests with normalized URL, query parameters, and headers', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: jest.fn().mockResolvedValue({ id: 1 }),
+    });
+
+    const client = new BacklogClient({
+      baseUrl: 'https://example.com/api',
+      apiKey: 'secret',
+    });
+
+    await client.get('/projects', { status: 'open', includeClosed: false, optional: undefined });
+
+    expect(createAuthHeaders).toHaveBeenCalledWith({ apiKey: 'secret' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/api/projects?status=open&includeClosed=false&apiKey=secret',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-API-Key': 'mock-header',
+        }),
+        body: undefined,
+      }),
+    );
+  });
+
+  it('serializes payloads for POST requests and returns parsed JSON responses', async () => {
+    const payload = { summary: 'Test issue' };
+    const responseBody = { id: 42 };
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: 'Created',
+      json: jest.fn().mockResolvedValue(responseBody),
+    });
+
+    const client = new BacklogClient('https://backlog.test/', 'api-key');
+    const result = await client.post('/issues', payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://backlog.test/issues?apiKey=api-key',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+    expect(result).toEqual(responseBody);
+  });
+
+  it('propagates rate limit responses as a special token', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      json: jest.fn(),
+    });
+
+    const client = new BacklogClient('https://backlog.test/', 'key');
+
+    await expect(client.get('/issues')).rejects.toBe('RATE_LIMIT');
+  });
+
+  it('throws descriptive errors for failed requests and preserves response details', async () => {
+    const errorText = 'Something went wrong';
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: jest.fn().mockResolvedValue(`  ${errorText}  `),
+      json: jest.fn(),
+    });
+
+    const client = new BacklogClient('https://backlog.test/', 'key');
+
+    await expect(client.delete('/issues/1')).rejects.toThrow('Backlog request failed with status 500');
+  });
+
+  it('returns undefined for 204 responses and rethrows JSON parsing errors', async () => {
+    const client = new BacklogClient('https://backlog.test/', 'key');
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+      json: jest.fn(),
+    });
+
+    const noContent = await client.delete('/issues/1');
+    expect(noContent).toBeUndefined();
+
+    const parseError = new Error('Invalid JSON');
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: jest.fn().mockRejectedValue(parseError),
+    });
+
+    await expect(client.get('/issues/2')).rejects.toThrow(parseError);
+  });
+});

--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -1,0 +1,240 @@
+import type { Tool } from '../src/tools/issues';
+
+type ToolKey =
+  | 'listIssues'
+  | 'getIssue'
+  | 'createIssue'
+  | 'updateIssue'
+  | 'deleteIssue'
+  | 'transitionIssue'
+  | 'issues'
+  | 'listComments'
+  | 'addComment'
+  | 'updateComment'
+  | 'deleteComment'
+  | 'attachments'
+  | 'activities'
+  | 'searchWiki'
+  | 'getWiki'
+  | 'createWiki'
+  | 'updateWiki'
+  | 'deleteWiki'
+  | 'wiki';
+
+type ToolMock = Tool<unknown, unknown> & { execute: jest.Mock };
+
+type ActiveContext = {
+  toolInstances: Record<ToolKey, ToolMock>;
+  registerToolMock: jest.Mock;
+  connectMock: jest.Mock;
+  serverInstance: { registerTool: jest.Mock; connect: jest.Mock };
+  transportInstance: Record<string, unknown>;
+  backlogClientInstance: Record<string, unknown>;
+  handleErrorMock: jest.Mock;
+  moduleExports?: typeof import('../src/server');
+};
+
+let activeContext: ActiveContext;
+
+const createMockTool = (name: ToolKey): ToolMock => ({
+  name,
+  description: `${name} tool`,
+  execute: jest.fn(),
+});
+
+jest.mock('@modelcontextprotocol/sdk/server', () => ({
+  Server: jest.fn(() => activeContext.serverInstance),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/stdio', () => ({
+  StdioServerTransport: jest.fn(() => activeContext.transportInstance),
+}));
+
+jest.mock('../src/backlogClient', () => ({
+  BacklogClient: jest.fn(() => activeContext.backlogClientInstance),
+}));
+
+jest.mock('../src/utils/errors', () => ({
+  handleError: jest.fn((...args) => activeContext.handleErrorMock(...args)),
+}));
+
+jest.mock('../src/tools/issues', () => ({
+  createListIssuesTool: jest.fn(() => activeContext.toolInstances.listIssues),
+  createGetIssueTool: jest.fn(() => activeContext.toolInstances.getIssue),
+  createCreateIssueTool: jest.fn(() => activeContext.toolInstances.createIssue),
+  createUpdateIssueTool: jest.fn(() => activeContext.toolInstances.updateIssue),
+  createDeleteIssueTool: jest.fn(() => activeContext.toolInstances.deleteIssue),
+  createTransitionIssueTool: jest.fn(() => activeContext.toolInstances.transitionIssue),
+  createIssuesTool: jest.fn(() => activeContext.toolInstances.issues),
+}));
+
+jest.mock('../src/tools/comments', () => ({
+  createListCommentsTool: jest.fn(() => activeContext.toolInstances.listComments),
+  createAddCommentTool: jest.fn(() => activeContext.toolInstances.addComment),
+  createUpdateCommentTool: jest.fn(() => activeContext.toolInstances.updateComment),
+  createDeleteCommentTool: jest.fn(() => activeContext.toolInstances.deleteComment),
+}));
+
+jest.mock('../src/tools/attachments', () => ({
+  createAttachmentsTool: jest.fn(() => activeContext.toolInstances.attachments),
+}));
+
+jest.mock('../src/tools/activities', () => ({
+  createActivitiesTool: jest.fn(() => activeContext.toolInstances.activities),
+}));
+
+jest.mock('../src/tools/wiki', () => ({
+  createSearchWikiTool: jest.fn(() => activeContext.toolInstances.searchWiki),
+  createGetWikiTool: jest.fn(() => activeContext.toolInstances.getWiki),
+  createCreateWikiTool: jest.fn(() => activeContext.toolInstances.createWiki),
+  createUpdateWikiTool: jest.fn(() => activeContext.toolInstances.updateWiki),
+  createDeleteWikiTool: jest.fn(() => activeContext.toolInstances.deleteWiki),
+  createWikiTool: jest.fn(() => activeContext.toolInstances.wiki),
+}));
+
+const allToolKeys: ToolKey[] = [
+  'listIssues',
+  'getIssue',
+  'createIssue',
+  'updateIssue',
+  'deleteIssue',
+  'transitionIssue',
+  'issues',
+  'listComments',
+  'addComment',
+  'updateComment',
+  'deleteComment',
+  'attachments',
+  'activities',
+  'searchWiki',
+  'getWiki',
+  'createWiki',
+  'updateWiki',
+  'deleteWiki',
+  'wiki',
+];
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  process.env = { ...originalEnv };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+const createContext = (): ActiveContext => {
+  const toolInstances = Object.fromEntries(
+    allToolKeys.map((key) => [key, createMockTool(key)]),
+  ) as Record<ToolKey, ToolMock>;
+
+  const registerToolMock = jest.fn();
+  const connectMock = jest.fn().mockResolvedValue(undefined);
+
+  return {
+    toolInstances,
+    registerToolMock,
+    connectMock,
+    serverInstance: { registerTool: registerToolMock, connect: connectMock },
+    transportInstance: { kind: 'transport' },
+    backlogClientInstance: {},
+    handleErrorMock: jest.fn(),
+  };
+};
+
+const loadServerModule = (context: ActiveContext) => {
+  activeContext = context;
+  context.moduleExports = require('../src/server');
+  return context.moduleExports!;
+};
+
+const getRegisteredTool = (context: ActiveContext, name: string) =>
+  context.registerToolMock.mock.calls.find(([definition]) => definition.name === name)?.[0];
+
+describe('server initialization', () => {
+  it('registers ping and Backlog tools and exports the server and transport instances', async () => {
+    process.env.BACKLOG_BASE_URL = 'https://example.backlog';
+    process.env.BACKLOG_API_KEY = 'test-key';
+
+    const context = createContext();
+    const moduleExports = loadServerModule(context);
+
+    const { Server } = require('@modelcontextprotocol/sdk/server');
+    const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio');
+    const { BacklogClient } = require('../src/backlogClient');
+
+    expect(Server).toHaveBeenCalledTimes(1);
+    expect(StdioServerTransport).toHaveBeenCalledTimes(1);
+    expect(BacklogClient).toHaveBeenCalledWith({
+      baseUrl: 'https://example.backlog',
+      apiKey: 'test-key',
+    });
+
+    expect(context.registerToolMock).toHaveBeenCalledTimes(1 + allToolKeys.length);
+
+    const pingRegistration = getRegisteredTool(context, 'ping');
+    expect(pingRegistration).toBeDefined();
+    const pingResult = await pingRegistration!.execute('hello');
+    expect(pingResult).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'pong:hello',
+        },
+      ],
+    });
+
+    const listIssuesRegistration = getRegisteredTool(context, 'listIssues');
+    expect(listIssuesRegistration).toBeDefined();
+    context.toolInstances.listIssues.execute.mockResolvedValueOnce({ success: true });
+    const wrappedResult = await listIssuesRegistration!.execute({ projectKey: 'EXAMPLE' });
+    expect(context.toolInstances.listIssues.execute).toHaveBeenCalledWith({ projectKey: 'EXAMPLE' });
+    expect(wrappedResult).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ success: true }, null, 2),
+        },
+      ],
+      structuredContent: { success: true },
+    });
+
+    expect(moduleExports.server).toBe(context.serverInstance);
+    expect(moduleExports.transport).toBe(context.transportInstance);
+  });
+
+  it('delegates tool failures to the shared error handler', async () => {
+    process.env.BACKLOG_BASE_URL = 'https://example.backlog';
+    process.env.BACKLOG_API_KEY = 'test-key';
+
+    const context = createContext();
+    const moduleExports = loadServerModule(context);
+    expect(moduleExports).toBeDefined();
+
+    const failingRegistration = getRegisteredTool(context, 'listIssues');
+    expect(failingRegistration).toBeDefined();
+
+    const failure = new Error('boom');
+    context.toolInstances.listIssues.execute.mockRejectedValueOnce(failure);
+    context.handleErrorMock.mockImplementationOnce(() => {
+      throw new Error('handled');
+    });
+
+    await expect(failingRegistration!.execute({})).rejects.toThrow('handled');
+    expect(context.handleErrorMock).toHaveBeenCalledWith(failure, { toolName: 'listIssues' });
+  });
+
+  it('throws a descriptive error when required environment variables are missing', () => {
+    delete process.env.BACKLOG_BASE_URL;
+    process.env.BACKLOG_API_KEY = 'present';
+
+    const context = createContext();
+
+    expect(() => loadServerModule(context)).toThrow(
+      'Missing required environment variable BACKLOG_BASE_URL for Backlog MCP server.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive Jest tests for BacklogClient request handling and error cases
- add server initialization tests covering tool registration and shared error handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d648138c83278f0090143cd1db5e