### PR TITLE
Add utility tests for auth and error helpers

### DIFF
--- a/__tests__/errors.test.ts
+++ b/__tests__/errors.test.ts
@@ -1,0 +1,105 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types';
+import { ZodError } from 'zod';
+
+import { BacklogError, handleError, normalizeError } from '../src/utils/errors';
+
+describe('BacklogError', () => {
+  it('preserves status and details information', () => {
+    const original = new BacklogError('Not found', {
+      status: 404,
+      details: { resource: 'issue' },
+    });
+
+    expect(original.status).toBe(404);
+    expect(original.details).toEqual({ resource: 'issue' });
+  });
+
+  it('marks fallback errors as the cause when normalizing', () => {
+    const fallback = new BacklogError('Fallback', { status: 400 });
+    const normalized = normalizeError({ foo: 'bar' }, fallback);
+
+    expect(normalized).toBeInstanceOf(BacklogError);
+    expect(normalized.message).toBe('Fallback');
+    expect((normalized as { cause?: unknown }).cause).toBe(fallback);
+    expect(normalized.details).toEqual({ foo: 'bar' });
+  });
+});
+
+describe('handleError', () => {
+  it('converts Backlog authentication failures into MCP errors', () => {
+    const error = new BacklogError('Auth failed', { status: 401 });
+
+    try {
+      handleError(error, { toolName: 'listIssues' });
+      fail('handleError should throw');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(McpError);
+      const mcpError = thrown as McpError;
+      expect(mcpError.code).toBe(-32002);
+      expect(mcpError.message).toContain('[listIssues] Backlog authentication failed.');
+      expect(mcpError.data).toEqual({ status: 401 });
+    }
+  });
+
+  it('wraps Zod validation errors', () => {
+    const zodError = new ZodError([]);
+
+    try {
+      handleError(zodError, { toolName: 'createIssue' });
+      fail('handleError should throw');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(McpError);
+      const mcpError = thrown as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InvalidParams);
+      expect(mcpError.message).toContain(
+        '[createIssue] Invalid parameters provided for Backlog tool.',
+      );
+      expect(mcpError.data).toEqual({ issues: [] });
+    }
+  });
+
+  it('extracts HTTP status codes from error messages', () => {
+    const cause = new Error('Request failed with status 503');
+
+    try {
+      handleError(cause, { toolName: 'attachments' });
+      fail('handleError should throw');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(McpError);
+      const mcpError = thrown as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InternalError);
+      expect(mcpError.message).toContain(
+        '[attachments] Backlog service encountered an internal error.',
+      );
+      expect(mcpError.data).toMatchObject({ status: 503, cause });
+    }
+  });
+
+  it('uses the fallback message when provided', () => {
+    try {
+      handleError('unexpected', {
+        toolName: 'createWiki',
+        fallbackMessage: 'Unable to complete the request.',
+      });
+      fail('handleError should throw');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(McpError);
+      const mcpError = thrown as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InternalError);
+      expect(mcpError.message).toContain('[createWiki] Unable to complete the request.');
+    }
+  });
+
+  it('handles Backlog rate limit responses consistently', () => {
+    try {
+      handleError('RATE_LIMIT', { toolName: 'listComments' });
+      fail('handleError should throw');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(McpError);
+      const mcpError = thrown as McpError;
+      expect(mcpError.code).toBe(-32004);
+      expect(mcpError.message).toContain('[listComments] Backlog API rate limit exceeded.');
+      expect(mcpError.data).toEqual({ status: 429 });
+    }
+  });
+});

--- a/__tests__/pagination.test.ts
+++ b/__tests__/pagination.test.ts
@@ -1,0 +1,58 @@
+import { buildPaginationParams, normalizePagination } from '../src/utils/pagination';
+
+describe('normalizePagination', () => {
+  it('returns undefined when no options provided', () => {
+    expect(normalizePagination()).toBeUndefined();
+  });
+
+  it('sanitizes offset and limit values', () => {
+    expect(
+      normalizePagination({
+        offset: -5.7,
+        limit: 0,
+      }),
+    ).toEqual({ offset: 0, limit: 1 });
+  });
+
+  it('discards invalid pagination values', () => {
+    expect(
+      normalizePagination({
+        offset: Number.NaN,
+        limit: Number.POSITIVE_INFINITY,
+      }),
+    ).toEqual({});
+  });
+});
+
+describe('buildPaginationParams', () => {
+  it('returns undefined when no normalized values exist', () => {
+    expect(buildPaginationParams(undefined)).toBeUndefined();
+    expect(
+      buildPaginationParams({
+        offset: Number.NaN,
+        limit: Number.NaN,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('maps normalized fields to Backlog query parameters', () => {
+    expect(
+      buildPaginationParams({
+        offset: 12.9,
+      }),
+    ).toEqual({ offset: 12 });
+
+    expect(
+      buildPaginationParams({
+        limit: 25.2,
+      }),
+    ).toEqual({ count: 25 });
+
+    expect(
+      buildPaginationParams({
+        offset: 5.8,
+        limit: 10.1,
+      }),
+    ).toEqual({ offset: 5, count: 10 });
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,33 @@
+import { createAuthHeaders } from '../src/utils/auth';
+import { BacklogError, isBacklogError, normalizeError } from '../src/utils/errors';
+
+describe('createAuthHeaders', () => {
+  it('returns an API key header when provided', () => {
+    const headers = createAuthHeaders({ apiKey: 'test-key' });
+
+    expect(headers).toEqual({ 'X-API-Key': 'test-key' });
+  });
+
+  it('throws when no API key is configured', () => {
+    expect(() => createAuthHeaders({ apiKey: '' })).toThrow(
+      'Backlog API key is required to authenticate requests.',
+    );
+  });
+});
+
+describe('Backlog utility helpers', () => {
+  it('identifies BacklogError instances', () => {
+    const error = new BacklogError('oops');
+
+    expect(isBacklogError(error)).toBe(true);
+    expect(isBacklogError(new Error('nope'))).toBe(false);
+  });
+
+  it('normalizes unknown values into BacklogError instances', () => {
+    const normalized = normalizeError({ unexpected: true });
+
+    expect(normalized).toBeInstanceOf(BacklogError);
+    expect(normalized.message).toBe('Unknown Backlog client error');
+    expect(normalized.details).toEqual({ unexpected: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for auth header creation in utility layer
- cover Backlog error helpers to ensure detection and normalization

## Testing
- npm test -- --watch=false *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e08dbc98832798373ffe5105437c